### PR TITLE
Remove feedback button and empty hamburger menu

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -61,26 +61,8 @@ header = ddsih.DangerouslySetInnerHTML(
     <a class="navbar-item" href="https://wrcc.dri.edu/">
       <img src="{path_prefix}assets/WRCC.svg">
     </a>
-
-    <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-    </a>
   </div>
 
-  <div class="navbar-menu">
-
-    <div class="navbar-end">
-      <div class="navbar-item">
-        <div class="buttons">
-          <a href="https://uaf-iarc.typeform.com/to/mN7J5cCK#tool=Historical%20Winds%20at%20Alaska%20Airports" class="button is-link" target="_blank">
-            Feedback
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
 </nav>
 </div>
 </header>


### PR DESCRIPTION
This PR removes the "Feedback" button from the navigation menu, and also removes the empty hamburger menu that shows up at mobile resolutions.